### PR TITLE
Add fallback inline CSS

### DIFF
--- a/scripts/openpose_editor.py
+++ b/scripts/openpose_editor.py
@@ -14,6 +14,8 @@ except NameError:
 
     root_path = pathlib.Path(inspect.getfile(lambda: None)).resolve().parents[1]
 
+css_path = root_path / "style.css"
+
 
 def get_asset_url(
     file_path: pathlib.Path, append: typing.Optional[dict[str, str]] = None
@@ -83,6 +85,7 @@ def create_ui():
         with gr.Tab(label="Edit Openpose"):
             gr.HTML(
                 f"""
+                <style>{css_path.read_text()}</style>
                 <iframe id="openpose3d_iframe" src="{html.escape(html_url)}"></iframe>
                 """
             )
@@ -206,7 +209,6 @@ def on_ui_settings():
 
 def main():
     js_path = root_path / "javascript" / "index.js"
-    css_path = root_path / "style.css"
 
     original_template_response = gr.routes.templates.TemplateResponse
     head = """


### PR DESCRIPTION
The changes add a `<style>` tag containing the same CSS used in the Gradio `Blocks` to use as fallback for different Gradio versions

Should fix https://github.com/nonnonstop/sd-webui-3d-open-pose-editor/issues/67, tested on https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/a9eab236d7e8afa4d6205127904a385b2c43bb24

<details>
  <summary>Preview</summary>

  ### Before
  ![before](https://user-images.githubusercontent.com/31524206/234153102-4b402ac6-2bdb-42a9-a869-f80790b97e4d.png)

  ---
  ### After
  ![after](https://user-images.githubusercontent.com/31524206/234153134-ea80c493-f19b-42a5-8b44-02f6a8c9b040.png)
   
</details>